### PR TITLE
Add better filtering on datetimes for meetings.

### DIFF
--- a/tests/test_vergadering.py
+++ b/tests/test_vergadering.py
@@ -1,3 +1,5 @@
+import datetime
+
 from tkapi.vergadering import Vergadering
 from tkapi.vergadering import VergaderingSoort
 
@@ -33,5 +35,18 @@ class TestVergaderingFilter(TKApiTestCase):
         max_items = 10
         filter = Vergadering.create_filter()
         filter.filter_soort(soort=VergaderingSoort.COMMISSIE)
-        verslagen = self.api.get_vergaderingen(filter=filter, max_items=max_items)
-        self.assertEqual(max_items, len(verslagen))
+        vergaderingen = self.api.get_vergaderingen(filter=filter, max_items=max_items)
+        self.assertEqual(max_items, len(vergaderingen))
+        self.assertTrue(
+            all([VergaderingSoort.COMMISSIE == vergadering.soort for vergadering in vergaderingen])
+        )
+
+    def test_veradering_changed_since_filter(self):
+        max_items = 10
+        filter_dt = datetime.datetime(2023, 1, 1, 00, 00, tzinfo=datetime.timezone.utc)
+        filter = Vergadering.create_filter()
+        filter.filter_changed_since(filter_dt)
+        vergaderingen = self.api.get_vergaderingen(filter=filter, max_items=max_items)
+        self.assertTrue(
+            all([vergadering.gewijzigd_op >= filter_dt for vergadering in vergaderingen])
+        )

--- a/tkapi/vergadering.py
+++ b/tkapi/vergadering.py
@@ -16,10 +16,16 @@ class VergaderingFilter(SoortFilter):
     def __init__(self):
         super().__init__()
 
-    def filter_date_range(self, begin_datetime, end_datetime):
+    def filter_date_range(self, begin_datetime, end_datetime=None):
         filter_str = "Begin ge {}".format(util.datetime_to_odata(begin_datetime))
         self._filters.append(filter_str)
-        filter_str = "Einde lt {}".format(util.datetime_to_odata(end_datetime))
+
+        if end_datetime:
+            filter_str = "Einde lt {}".format(util.datetime_to_odata(end_datetime))
+            self._filters.append(filter_str)
+
+    def filter_changed_since(self, since_datetime):
+        filter_str = "ApiGewijzigdOp ge {}".format(util.datetime_to_odata(since_datetime))
         self._filters.append(filter_str)
 
 


### PR DESCRIPTION
As a user I would like to be able to filter out changes to meetings and also have all meetings after a certain date. This PR implements both.

Additionally, it changes the existing test for filtering on meeting "Soort" since that previously didn't really test the filter was doing it's job.